### PR TITLE
Fix rendering in namespaced controllers

### DIFF
--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -3,8 +3,11 @@ module Components
     def component(name, props = {})
       yield props if block_given?
 
+      component = "#{name}_component".classify.constantize.new(props)
+
       render(
-        "#{name}_component".classify.constantize.new(props)
+        partial: "#{name}/#{name}",
+        object: component
       )
     end
   end

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -29,10 +29,5 @@ module Components
         raise "Unknown props passed to #{self.class.name}: #{props.keys}"
       end
     end
-
-    def to_partial_path
-      name = self.class.name.chomp('Component').underscore
-      "#{name}/#{name}"
-    end
   end
 end


### PR DESCRIPTION
When rendering a component in a namespaced controller, Rails prefixes the partial path with the controller namespace by default, if you pass an object to render. The solution is to not leverate `to_partial_path`. 