### PR TITLE
Typed component attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ Let's add some markup and CSS:
 /* app/components/panel/panel.css */
 
 .Panel {
-  // ...
+  border: 1px solid black;
 }
 
 .Panel-header {
-  // ...
+  font-weight: bold;
 }
 
 .Panel-body {
-  // ...
+  font-weight: normal;
 }
 ```
 
@@ -73,7 +73,9 @@ This component can now be rendered using the `component` helper:
 <%= component :panel %>
 ```
 
-In order to add assets, either require them manually in e.g. `application.css`:
+### Component assets
+
+In order to require assets such as CSS, either require them manually in e.g. `application.css`:
 
 ```css
 /*
@@ -81,7 +83,7 @@ In order to add assets, either require them manually in e.g. `application.css`:
  */
 ```
 
-Or require `components`, which will in turn require all assets:
+Or require `components`, which will in turn require the assets for all components:
 
 ```css
 /*
@@ -89,14 +91,16 @@ Or require `components`, which will in turn require all assets:
  */
 ```
 
+### Component data
+
 Let's define some data that we can pass to the component:
 
 ```ruby
 # app/components/panel/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  prop :header
-  prop :body
+  attribute :header, Components::Types::String
+  attribute :body, Components::Types::String
 end
 ```
 
@@ -120,8 +124,8 @@ end
 If we want to assign something more interesting than a string, we can pass a block to `component` and leverage Rails `capture` helper:
 
 ```erb
-<%= component :panel, header: "Header" do |props| %>
-  <% props[:body] = capture do %>
+<%= component :panel, header: "Header" do |attrs| %>
+  <% attrs[:body] = capture do %>
     <ul>
       <li>...</li>
     </ul>
@@ -132,23 +136,25 @@ If we want to assign something more interesting than a string, we can pass a blo
 This means we can nest components:
 
 ```erb
-<%= component :panel, header: "Header" do |props| %>
-  <% props[:body] = capture do %>
+<%= component :panel, header: "Header" do |attrs| %>
+  <% attrs[:body] = capture do %>
     <%= component :panel, header: "Nested panel header", body: "Nested panel body" %>
   <% end %>
 <% end %>
 ```
 
-### Prop defaults
+### Attribute types and defaults
 
-We can assign default values to props:
+Components are built on top of the [dry-struct](https://github.com/dry-rb/dry-struct) library, which in turn is built on top of [dry-types](https://github.com/dry-rb/dry-types). Consult http://dry-rb.org/gems/dry-types for a list of built in types and how to use them.
+
+Attributes can have default values:
 
 ```ruby
 # app/components/panel/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  prop :header, default: 'Some default'
-  prop :body
+  attribute :header, Components::Types::String.default('Some default')
+  attribute :body, Components::Types::String
 end
 ```
 
@@ -156,16 +162,16 @@ end
 <%= component :panel, body: "Body" %>
 ```
 
-### Prop overrides
+### Attribute overrides
 
-It's easy to override a prop with additional logic:
+It's easy to override an attribute with additional logic:
 
 ```ruby
 # app/components/panel/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  prop :header
-  prop :body
+  attribute :header, Components::Types::String
+  attribute :body, Components::Types::String
 
   def header
     @header.titleize
@@ -181,8 +187,8 @@ In addition to overriding already defined methods, we can declare our own:
 # app/components/panel/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  prop :header
-  prop :body
+  attribute :header, Components::Types::String
+  attribute :body, Components::Types::String
 
   def long_body?
     body.length > 100
@@ -190,7 +196,7 @@ class PanelComponent < Components::Component
 end
 ```
 
-We can access these from the template just like props:
+We can access these from the template just like attributes:
 
 ```erb
 <% # app/components/panel/_panel.html.erb %>

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,9 +1,9 @@
 module Components
   module ComponentHelper
-    def component(name, props = {})
-      yield props if block_given?
+    def component(name, attrs = {})
+      yield attrs if block_given?
 
-      component = "#{name}_component".classify.constantize.new(props)
+      component = "#{name}_component".classify.constantize.new(attrs)
 
       render(
         partial: "#{name}/#{name}",

--- a/components.gemspec
+++ b/components.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
+  s.add_dependency 'dry-struct', '>= 0.4.0'
   s.add_dependency 'rails', '>= 5.1.0'
 
   s.add_development_dependency 'sqlite3'

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,33 +1,11 @@
+require 'dry-struct'
+
 module Components
-  class Component
-    class << self
-      def props
-        @_props ||= {}
-      end
+  module Types
+    include Dry::Types.module
+  end
 
-      def prop(prop, default: nil)
-        props[prop] = { default: default }
-
-        define_method(prop) do
-          instance_variable_get("@#{prop}")
-        end
-      end
-    end
-
-    def initialize(props)
-      self.class.props.each do |prop_name, prop_options|
-        value = props.delete(prop_name) || prop_options[:default]
-
-        unless value.present?
-          raise "Prop must be passed to #{self.class.name} or assigned a default value: #{prop_name}"
-        end
-
-        instance_variable_set("@#{prop_name}", value)
-      end
-
-      unless props.keys.empty?
-        raise "Unknown props passed to #{self.class.name}: #{props.keys}"
-      end
-    end
+  class Component < Dry::Struct
+    constructor_type :strict_with_defaults
   end
 end

--- a/test/dummy/app/components/panel/panel_component.rb
+++ b/test/dummy/app/components/panel/panel_component.rb
@@ -1,4 +1,4 @@
 class PanelComponent < Components::Component
-  prop :header
-  prop :body
+  attribute :header, Components::Types::String
+  attribute :body, Components::Types::String
 end

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -1,7 +1,7 @@
 <%= component :panel, header: "Foo", body: "Bar" %>
 
-<%= component :panel, header: "Foo" do |props| %>
-  <% props[:body] = capture do %>
+<%= component :panel, header: "Foo" do |attrs| %>
+  <% attrs[:body] = capture do %>
     Bar
   <% end %>
 <% end %>


### PR DESCRIPTION
This PR adds types to component attributes using https://github.com/dry-rb/dry-struct and https://github.com/dry-rb/dry-types. It also renames props to attributes, to better match the dry libraries.