### PR TITLE
Simplify usage of blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,25 +121,32 @@ end
 <%= component :panel, header: "Header", body: "Body" %>
 ```
 
-If we want to assign something more interesting than a string, we can pass a block to `component` and leverage Rails `capture` helper:
+If we want to assign something more interesting than an inline string, we can pass a block to `component`. This will assign the value of the block to an attribute of our choice:
+
+```ruby
+# app/components/panel/panel_component.rb %>
+
+class PanelComponent < Components::Component
+  BLOCK_ATTRIBUTE = :body
+
+  attribute :header, Components::Types::String
+  attribute :body, Components::Types::String
+end
+```
 
 ```erb
-<%= component :panel, header: "Header" do |attrs| %>
-  <% attrs[:body] = capture do %>
-    <ul>
-      <li>...</li>
-    </ul>
-  <% end %>
+<%= component :panel, header: "Header" do %>
+  <ul>
+    <li>...</li>
+  </ul>
 <% end %>
 ```
 
 This means we can nest components:
 
 ```erb
-<%= component :panel, header: "Header" do |attrs| %>
-  <% attrs[:body] = capture do %>
-    <%= component :panel, header: "Nested panel header", body: "Nested panel body" %>
-  <% end %>
+<%= component :panel, header: "Header" do %>
+  <%= component :panel, header: "Nested panel header", body: "Nested panel body" %>
 <% end %>
 ```
 

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,13 +1,17 @@
 module Components
   module ComponentHelper
     def component(name, attrs = {})
-      yield attrs if block_given?
+      component_class = "#{name}_component".classify.constantize
 
-      component = "#{name}_component".classify.constantize.new(attrs)
+      if block_given?
+        attrs.reverse_merge!(
+          component_class::BLOCK_ATTRIBUTE => capture { yield }
+        )
+      end
 
       render(
         partial: "#{name}/#{name}",
-        object: component
+        object: component_class.new(attrs)
       )
     end
   end

--- a/test/dummy/app/components/panel/panel_component.rb
+++ b/test/dummy/app/components/panel/panel_component.rb
@@ -1,4 +1,6 @@
 class PanelComponent < Components::Component
+  BLOCK_ATTRIBUTE = :body
+
   attribute :header, Components::Types::String
   attribute :body, Components::Types::String
 end

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -1,7 +1,5 @@
 <%= component :panel, header: "Foo", body: "Bar" %>
 
-<%= component :panel, header: "Foo" do |attrs| %>
-  <% attrs[:body] = capture do %>
-    Bar
-  <% end %>
+<%= component :panel, header: "Foo" do %>
+  Bar
 <% end %>


### PR DESCRIPTION
This PR changes the behavior of passing blocks to components. The way we have it now is very flexible, but perhaps a bit verbose for normal use? It seems probable that in most cases you only need one yield. If you need more you can always capture them before and pass as normal arguments.

Most other libraries have a standard name for the attribute of the yield, which I guess we could do as well. I though perhaps since we have types it should be added to the component nonetheless by the user that it expects a string argument. And I was thinking it shouldn't really matter if it comes from a block or passed as an argument, hence the mapping between the two. Not sure!