### PR TITLE
Remove types

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Let's define some data that we can pass to the component:
 # app/components/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  attribute :header, Components::Types::Strict::String
-  attribute :body, Components::Types::Strict::String
+  attribute :header
+  attribute :body
 end
 ```
 
@@ -143,9 +143,18 @@ This means we can nest components:
 <% end %>
 ```
 
-### Attribute types and defaults
+### Attribute defaults
 
-Components are built on top of the [dry-struct](https://github.com/dry-rb/dry-struct) library, which in turn is built on top of [dry-types](https://github.com/dry-rb/dry-types). Consult http://dry-rb.org/gems/dry-types for a list of built in types and how to use them.
+Attributes can have default values:
+
+```ruby
+# app/components/panel_component.rb %>
+
+class PanelComponent < Components::Component
+  attribute :header, default: "Default value"
+  attribute :body
+end
+```
 
 ### Attribute overrides
 
@@ -155,11 +164,11 @@ It's easy to override an attribute with additional logic:
 # app/components/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  attribute :header, Components::Types::Strict::String
-  attribute :body, Components::Types::Strict::String
+  attribute :header
+  attribute :body
 
   def header
-    @attributes[:header].titleize
+    @header.titleize
   end
 end
 ```
@@ -172,8 +181,8 @@ In addition to overriding already defined methods, we can declare our own:
 # app/components/panel_component.rb %>
 
 class PanelComponent < Components::Component
-  attribute :header, Components::Types::Strict::String
-  attribute :body, Components::Types::Strict::String
+  attribute :header
+  attribute :body
 
   def long_body?
     body.length > 100

--- a/components.gemspec
+++ b/components.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'dry-struct', '>= 0.5.0'
   s.add_dependency 'rails', '>= 5.1.0'
 
   s.add_development_dependency 'sqlite3'

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,10 +1,23 @@
-require 'dry-struct'
-
 module Components
-  module Types
-    include Dry::Types.module
-  end
+  class Component
+    class << self
+      def attributes
+        @attributes ||= {}
+      end
 
-  class Component < Dry::Struct
+      def attribute(attribute, default: nil)
+        attributes[attribute] = { default: default }
+
+        define_method(attribute) do
+          instance_variable_get("@#{attribute}")
+        end
+      end
+    end
+
+    def initialize(attributes)
+      self.class.attributes.each do |name, options|
+        instance_variable_set("@#{name}", attributes.delete(name) || options[:default])
+      end
+    end
   end
 end

--- a/test/dummy/app/components/card/section_component.rb
+++ b/test/dummy/app/components/card/section_component.rb
@@ -1,5 +1,5 @@
 module Card
   class SectionComponent < Components::Component
-    attribute :body, Components::Types::Strict::String
+    attribute :body
   end
 end

--- a/test/dummy/app/components/card_component.rb
+++ b/test/dummy/app/components/card_component.rb
@@ -1,5 +1,5 @@
 class CardComponent < Components::Component
-  attribute :header, Components::Types::Strict::String
-  attribute :sections, Components::Types::Strict::String
-  attribute :footer, Components::Types::Strict::String
+  attribute :header
+  attribute :sections
+  attribute :footer
 end

--- a/test/dummy/app/components/panel_component.rb
+++ b/test/dummy/app/components/panel_component.rb
@@ -1,4 +1,4 @@
 class PanelComponent < Components::Component
-  attribute :header, Components::Types::Strict::String
-  attribute :body, Components::Types::Strict::String
+  attribute :header
+  attribute :body
 end


### PR DESCRIPTION
This PR removes types and the dependency on `dry-types`. This in order to simplify in preparation for taking on subcomponents.