### PR TITLE
Elements within elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,16 @@
+AllCops:
+  TargetRubyVersion: 2.2.2
+
 Metrics/LineLength:
   Max: 120
 
-Metrics/MethodLength:
-  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*.rb'
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/README.md
+++ b/README.md
@@ -250,19 +250,19 @@ end
 Elements are declared using `has_one` or `has_many`. Passing them a block lets us declare attributes on our elements, in the same way we declare attributes on components. To inject content into these elements, we pass a block to the component helper:
 
 ```erb
-<%= component "card", flush: true do |c| %>
-  <% c.header "Header", centered: true %>
-  <% c.section "Section 1", size: "large" %>
-  <% c.section "Section 2", size: "small" %>
-  <% c.footer "Footer" %>
+<%= component "card", flush: true do |card| %>
+  <% card.header "Header", centered: true %>
+  <% card.section "Section 1", size: "large" %>
+  <% card.section "Section 2", size: "small" %>
+  <% card.footer "Footer" %>
 <% end %>
 ```
 
 To inject HTML content into the elements, pass a block to the element instead of a string value:
 
 ```erb
-<%= component "card", flush: true do |c| %>
-  <% c.header centered: true do %>
+<%= component "card", flush: true do |card| %>
+  <% card.header centered: true do %>
     <strong>Header</strong>
   <% end %>
   ...
@@ -283,9 +283,9 @@ end
 ```
 
 ```erb
-<%= component "navigation" do |c| %>
-  <% c.items "Home", url: root_path, active: true %>
-  <% c.items "Explore" url: explore_path %>
+<%= component "navigation" do |navigation| %>
+  <% navigation.items "Home", url: root_path, active: true %>
+  <% navigation.items "Explore" url: explore_path %>
 <% end %>
 ```
 
@@ -293,6 +293,41 @@ An alternative here is to pass a data structure to the component as an attribute
 
 ```erb
 <%= component "navigation", items: items %>
+```
+
+The component is itself an element, which means it also has a value, same as other elements. If you have a simple component that only needs one element, you can use the component itself:
+
+```erb
+<%= component "alert", context: "success" do %>
+  Something went right!
+<% end %>
+```
+
+The component's value can then be accessed in the partial:
+
+```erb
+<% # app/components/alert/_alert.html.erb %>
+
+<div class="alert alert--<%= context %>" role="alert">
+  <%= @_component.value %>
+</div>
+```
+
+Elements can also be nested, although it is recommended to keep nesting to a minimum:
+
+```ruby
+# app/components/card_component.rb %>
+
+class CardComponent < Components::Component
+  ...
+
+  has_many :sections do
+    attribute :size
+
+    has_one :header
+    has_one :footer
+  end
+end
 ```
 
 ### Helper methods

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The component's value can then be accessed in the partial:
 <% # app/components/alert/_alert.html.erb %>
 
 <div class="alert alert--<%= context %>" role="alert">
-  <%= @_component.value %>
+  <%= value %>
 </div>
 ```
 

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,9 +1,7 @@
 module Components
   module ComponentHelper
-    def component(name, attrs = {})
-      component = "#{name}_component".classify.constantize.new(self, attrs)
-
-      yield component if block_given?
+    def component(name, attrs = {}, &block)
+      component = "#{name}_component".classify.constantize.new(self, nil, attrs, &block)
 
       view = controller.view_context
       view.instance_variable_set(:@_component, component)

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -6,7 +6,10 @@ module Components
       view = controller.view_context
       view.instance_variable_set(:@_component, component)
 
-      component.public_methods(false).each do |method|
+      methods = component.public_methods(false)
+      methods << :value
+
+      methods.each do |method|
         view.singleton_class.delegate method, to: :@_component
       end
 

--- a/app/helpers/components/navigation_helper.rb
+++ b/app/helpers/components/navigation_helper.rb
@@ -1,5 +1,6 @@
 module Components
   module NavigationHelper
+    # rubocop:disable Metrics/MethodLength
     def navigation(pages = nil, paths = [])
       content_tag :ul do
         (pages || Components.page_names).map do |page|
@@ -16,5 +17,6 @@ module Components
         end.join('').html_safe
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/components/attributes.rb
+++ b/lib/components/attributes.rb
@@ -20,7 +20,7 @@ module Components
 
     def assign_attributes(attributes = {})
       self.class.attributes.each do |name, options|
-        set_attribute(name, attributes.delete(name) || options[:default]&.dup)
+        set_attribute(name, attributes.delete(name) || (options[:default] && options[:default].dup))
       end
     end
 

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,5 +1,7 @@
 module Components
   class Component
+    # TODO: include Element here instead
+
     include Attributes
     include Elements
 

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,13 +1,4 @@
 module Components
-  class Component
-    # TODO: include Element here instead
-
-    include Attributes
-    include Elements
-
-    def initialize(view, attributes = nil)
-      @view = view
-      assign_attributes(attributes || {})
-    end
+  class Component < Element
   end
 end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -5,19 +5,20 @@ module Components
 
     attr_accessor :value
 
-    def initialize(view, value, attributes = nil)
+    def initialize(view, value = nil, attributes = nil, &block)
       @view = view
-      @value = value
+      @value = block ? capture(&block) : value
       assign_attributes(attributes || {})
-    end
-
-    # TODO: can this be moved to initialize?
-    def value_from_block(&block)
-      @value = @view.capture(self, &block)
     end
 
     def to_s
       @value
+    end
+
+    private
+
+    def capture(&block)
+      @view.capture(self, &block)
     end
   end
 end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -1,6 +1,7 @@
 module Components
   class Element
     include Attributes
+    include Elements
 
     attr_accessor :value
 

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -11,6 +11,11 @@ module Components
       assign_attributes(attributes || {})
     end
 
+    # TODO: can this be moved to initialize?
+    def value_from_block(&block)
+      @value = @view.capture(self, &block)
+    end
+
     def to_s
       @value
     end

--- a/lib/components/elements.rb
+++ b/lib/components/elements.rb
@@ -8,13 +8,11 @@ module Components
         define_method(name) do |value = nil, attributes = nil, &block|
           return get_element(name) unless value || block
 
-          # TODO: this and the same for has many is identical
           element_class = config ? Class.new(Element, &config) : Element
-          attributes, value = value, nil if block
-          element = element_class.new(@view, value, attributes)
-          element.value_from_block(&block) if block
 
-          set_element(name, element)
+          set_element(
+            name, element(element_class, value, attributes, &block)
+          )
         end
       end
 
@@ -22,19 +20,22 @@ module Components
         define_method(name) do |value = nil, attributes = nil, &block|
           return get_element(name, collection: true) unless value || block
 
-          # TODO: this and the same for has one is identical
           element_class = config ? Class.new(Element, &config) : Element
-          attributes, value = value, nil if block
-          element = element_class.new(@view, value, attributes)
-          element.value_from_block(&block) if block
 
-          set_element(name, element, collection: true)
+          set_element(
+            name, element(element_class, value, attributes, &block), collection: true
+          )
         end
       end
     end
     # rubocop:enable Naming/PredicateName
 
     private
+
+    def element(element_class, value, attributes, &block)
+      attributes, value = value, nil if block
+      element_class.new(@view, value, attributes, &block)
+    end
 
     def get_element(name, collection: false)
       unless instance_variable_defined?(:"@#{name}")

--- a/lib/components/elements.rb
+++ b/lib/components/elements.rb
@@ -5,33 +5,29 @@ module Components
     class_methods do
       def has_one(name, &config)
         define_method(name) do |value = nil, attributes = nil, &block|
+          return get_element(name) unless value || block
+
+          element_class = config ? Class.new(Element, &config) : Element
+
           attributes, value = value, @view.capture(&block) if block
 
-          if value
-            element_class = config ? Class.new(Element, &config) : Element
-
-            set_element(
-              name, element_class.new(@view, value, attributes)
-            )
-          else
-            get_element(name)
-          end
+          set_element(
+            name, element_class.new(@view, value, attributes)
+          )
         end
       end
 
       def has_many(name, &config)
         define_method(name) do |value = nil, attributes = nil, &block|
+          return get_element(name, collection: true) unless value || block
+
+          element_class = config ? Class.new(Element, &config) : Element
+
           attributes, value = value, @view.capture(&block) if block
 
-          if value
-            element_class = config ? Class.new(Element, &config) : Element
-
-            set_element(
-              name, element_class.new(@view, value, attributes), collection: true
-            )
-          else
-            get_element(name, collection: true)
-          end
+          set_element(
+            name, element_class.new(@view, value, attributes), collection: true
+          )
         end
       end
     end

--- a/lib/components/elements.rb
+++ b/lib/components/elements.rb
@@ -2,18 +2,19 @@ module Components
   module Elements
     extend ActiveSupport::Concern
 
+    # rubocop:disable Naming/PredicateName
     class_methods do
       def has_one(name, &config)
         define_method(name) do |value = nil, attributes = nil, &block|
           return get_element(name) unless value || block
 
+          # TODO: this and the same for has many is identical
           element_class = config ? Class.new(Element, &config) : Element
+          attributes, value = value, nil if block
+          element = element_class.new(@view, value, attributes)
+          element.value_from_block(&block) if block
 
-          attributes, value = value, @view.capture(&block) if block
-
-          set_element(
-            name, element_class.new(@view, value, attributes)
-          )
+          set_element(name, element)
         end
       end
 
@@ -21,16 +22,17 @@ module Components
         define_method(name) do |value = nil, attributes = nil, &block|
           return get_element(name, collection: true) unless value || block
 
+          # TODO: this and the same for has one is identical
           element_class = config ? Class.new(Element, &config) : Element
+          attributes, value = value, nil if block
+          element = element_class.new(@view, value, attributes)
+          element.value_from_block(&block) if block
 
-          attributes, value = value, @view.capture(&block) if block
-
-          set_element(
-            name, element_class.new(@view, value, attributes), collection: true
-          )
+          set_element(name, element, collection: true)
         end
       end
     end
+    # rubocop:enable Naming/PredicateName
 
     private
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -1,6 +1,18 @@
 require 'test_helper'
 
 class ComponentTest < ActiveSupport::TestCase
+  test 'initialize with value' do
+    component_class = Class.new(Components::Component)
+    component = component_class.new(:view, 'foo')
+    assert_equal 'foo', component.instance_variable_get(:@value)
+  end
+
+  test 'get value' do
+    component_class = Class.new(Components::Component)
+    component = component_class.new(:view, 'foo')
+    assert_equal component.instance_variable_get(:@value), component.value
+  end
+
   test 'initialize attribute with no value' do
     component_class = Class.new(Components::Component) do
       attribute :foo
@@ -13,7 +25,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       attribute :foo
     end
-    component = component_class.new(:view, foo: 'foo')
+    component = component_class.new(:view, nil, foo: 'foo')
     assert_equal 'foo', component.instance_variable_get(:@foo)
   end
 
@@ -29,7 +41,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       attribute :foo
     end
-    component = component_class.new(:view, foo: 'foo')
+    component = component_class.new(:view, nil, foo: 'foo')
     assert_equal component.instance_variable_get(:@foo), component.foo
   end
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -114,4 +114,24 @@ class ComponentTest < ActiveSupport::TestCase
     component = component_class.new(:view)
     assert_equal [], component.foo
   end
+
+  # test 'set foo' do
+  #   view_class = Class.new do
+  #     def capture
+  #       yield
+  #     end
+  #   end
+  #   component_class = Class.new(Components::Component) do
+  #     has_one :foo do
+  #       has_one :bar
+  #     end
+  #   end
+  #   component = component_class.new(view_class.new)
+  #   component.foo do |cc|
+  #     cc.bar { 'bar' }
+  #     'foo'
+  #   end
+  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
+  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  # end
 end

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -44,8 +44,8 @@ class ComponentTest < ActiveSupport::TestCase
 
   test 'set element with block' do
     view_class = Class.new do
-      def capture
-        yield
+      def capture(element)
+        yield(element)
       end
     end
     component_class = Class.new(Components::Component) do
@@ -117,8 +117,8 @@ class ComponentTest < ActiveSupport::TestCase
 
   # test 'set foo' do
   #   view_class = Class.new do
-  #     def capture
-  #       yield
+  #     def capture(element)
+  #       yield(element)
   #     end
   #   end
   #   component_class = Class.new(Components::Component) do
@@ -127,11 +127,12 @@ class ComponentTest < ActiveSupport::TestCase
   #     end
   #   end
   #   component = component_class.new(view_class.new)
-  #   component.foo do |cc|
-  #     cc.bar { 'bar' }
+  #   component.foo baz: 'baz' do |cc|
+  #     cc.bar { 'bar' } # TODO: value or block?
   #     'foo'
   #   end
   #   assert_equal 'foo', component.instance_variable_get(:@foo).value
   #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  #   assert_equal 'baz', component.instance_variable_get(:@foo).baz # why doesn't this work?
   # end
 end

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -43,11 +43,6 @@ class ComponentTest < ActiveSupport::TestCase
   end
 
   test 'set element with block' do
-    view_class = Class.new do
-      def capture(element)
-        yield(element)
-      end
-    end
     component_class = Class.new(Components::Component) do
       has_one :foo
     end
@@ -90,6 +85,36 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
   end
 
+  test 'set element with nested element' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo do
+        has_one :bar
+      end
+    end
+    component = component_class.new(view_class.new)
+    component.foo baz: 'baz' do |cc|
+      cc.bar 'bar'
+      'foo'
+    end
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  end
+
+  test 'set element with nested element with block' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo do
+        has_one :bar
+      end
+    end
+    component = component_class.new(view_class.new)
+    component.foo baz: 'baz' do |cc|
+      cc.bar { 'bar' }
+      'foo'
+    end
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  end
+
   test 'get element' do
     component_class = Class.new(Components::Component) do
       has_one :foo
@@ -115,24 +140,13 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal [], component.foo
   end
 
-  # test 'set foo' do
-  #   view_class = Class.new do
-  #     def capture(element)
-  #       yield(element)
-  #     end
-  #   end
-  #   component_class = Class.new(Components::Component) do
-  #     has_one :foo do
-  #       has_one :bar
-  #     end
-  #   end
-  #   component = component_class.new(view_class.new)
-  #   component.foo baz: 'baz' do |cc|
-  #     cc.bar { 'bar' } # TODO: value or block?
-  #     'foo'
-  #   end
-  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
-  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
-  #   assert_equal 'baz', component.instance_variable_get(:@foo).baz # why doesn't this work?
-  # end
+  private
+
+  def view_class
+    Class.new do
+      def capture(element)
+        yield(element)
+      end
+    end
+  end
 end

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,13 +1,22 @@
 <div id="<%= id %>" class="card">
-  <div class="card__header">
-    <%= header %>
-  </div>
+  <% if header.present? %>
+    <div class="card__header">
+      <%= header %>
+    </div>
+  <% end %>
   <% sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
+      <% if section.header.present? %>
+        <div class="card__section__header">
+          <%= section.header %>
+        </div>
+      <% end %>
       <%= section %>
     </div>
   <% end %>
-  <div class="card__footer">
-    <%= footer %>
-  </div>
+  <% if footer.present? %>
+    <div class="card__footer">
+      <%= footer %>
+    </div>
+  <% end %>
 </div>

--- a/test/dummy/app/components/card_component.rb
+++ b/test/dummy/app/components/card_component.rb
@@ -4,6 +4,7 @@ class CardComponent < Components::Component
   has_one :header
   has_many :sections do
     attribute :size
+    has_one :header
   end
   has_one :footer
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,5 +11,4 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 0) do
-
 end

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -23,10 +23,10 @@ class ComponentHelperTest < ActionView::TestCase
 
   test 'render component setting elements with blocks' do
     output = component 'card', id: 'id' do |c|
-      c.header 'Header'
+      c.header { 'Header' }
       c.sections(size: 'large') { 'Section 1' }
       c.sections(size: 'small') { 'Section 2' }
-      c.footer 'Footer'
+      c.footer { 'Footer' }
     end
 
     assert_dom_equal_squished %(
@@ -34,6 +34,37 @@ class ComponentHelperTest < ActionView::TestCase
         <div class="card__header"> Header </div>
         <div class="card__section card__section--large"> Section 1 </div>
         <div class="card__section card__section--small"> Section 2 </div>
+        <div class="card__footer"> Footer </div>
+      </div>
+    ), output
+  end
+
+  test 'render component setting nested elements' do
+    output = component 'card', id: 'id' do |c|
+      c.header 'Header'
+      c.header { 'Header' }
+      c.sections do |cc|
+        cc.header { 'Section Header 1' }
+        'Section 1'
+      end
+      c.sections do |cc|
+        cc.header { 'Section Header 2' }
+        'Section 2'
+      end
+      c.footer { 'Footer' }
+    end
+
+    assert_dom_equal_squished %(
+      <div id="id" class="card">
+        <div class="card__header"> Header </div>
+        <div class="card__section">
+          <div class="card__section__header"> Section Header 1 </div>
+          Section 1
+        </div>
+        <div class="card__section">
+          <div class="card__section__header"> Section Header 2 </div>
+          Section 2
+        </div>
         <div class="card__footer"> Footer </div>
       </div>
     ), output


### PR DESCRIPTION
This PR fixes #15 by tweaking the API to make it more consistent, and by adding some new features. It is now possible to nest elements within elements, and the root component is itself now an element, and has a value. That means you don't need an element if you just want to capture some HTML for your component:

```erb
<%= component "alert" do %>
  Some content, without an element
<% end %>
```

## Todo

- [x] Update README