### PR TITLE
Remove value in favor of content

### DIFF
--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,7 +1,7 @@
 module Components
   module ComponentHelper
     def component(name, attrs = {}, &block)
-      component = "#{name}_component".classify.constantize.new(self, nil, attrs, &block)
+      component = "#{name}_component".classify.constantize.new(self, attrs, &block)
 
       view = controller.view_context
       view.instance_variable_set(:@_component, component)

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -7,7 +7,7 @@ module Components
       view.instance_variable_set(:@_component, component)
 
       methods = component.public_methods(false)
-      methods << :value
+      methods << :content
 
       methods.each do |method|
         view.singleton_class.delegate method, to: :@_component

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -3,18 +3,12 @@ module Components
     include Attributes
     include Elements
 
-    attr_reader :value
+    attr_reader :content
 
     def initialize(view, attributes = nil, &block)
       @view = view
-      attributes ||= {}
-      @value = attributes.delete(:value)
-      @value = capture(&block) if block
-      assign_attributes(attributes)
-    end
-
-    def to_s
-      @value
+      @content = capture(&block) if block
+      assign_attributes(attributes || {})
     end
 
     private

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -3,12 +3,26 @@ module Components
     include Attributes
     include Elements
 
-    attr_accessor :value
+    # TODO: this works when inheriting from element, but not when instantiating an element directly..
+    # is that an issue? it would sorta be better if attributes could be inherited? otherwise you
+    # can't inherit components either.. come to think of it..
+    def self.inherited(other)
+      other.attribute :value
+    end
 
-    def initialize(view, value = nil, attributes = nil, &block)
+    # attr_accessor :value
+
+    # def initialize(view, value = nil, attributes = nil, &block)
+    #   @view = view
+    #   @value = block ? capture(&block) : value
+    #   assign_attributes(attributes || {})
+    # end
+
+    def initialize(view, attributes = nil, &block)
       @view = view
-      @value = block ? capture(&block) : value
-      assign_attributes(attributes || {})
+      attributes ||= {}
+      attributes[:value] = capture(&block) if block
+      assign_attributes(attributes)
     end
 
     def to_s

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -3,25 +3,13 @@ module Components
     include Attributes
     include Elements
 
-    # TODO: this works when inheriting from element, but not when instantiating an element directly..
-    # is that an issue? it would sorta be better if attributes could be inherited? otherwise you
-    # can't inherit components either.. come to think of it..
-    def self.inherited(other)
-      other.attribute :value
-    end
-
-    # attr_accessor :value
-
-    # def initialize(view, value = nil, attributes = nil, &block)
-    #   @view = view
-    #   @value = block ? capture(&block) : value
-    #   assign_attributes(attributes || {})
-    # end
+    attr_reader :value
 
     def initialize(view, attributes = nil, &block)
       @view = view
       attributes ||= {}
-      attributes[:value] = capture(&block) if block
+      @value = attributes.delete(:value)
+      @value = capture(&block) if block
       assign_attributes(attributes)
     end
 

--- a/lib/components/elements.rb
+++ b/lib/components/elements.rb
@@ -5,37 +5,30 @@ module Components
     # rubocop:disable Naming/PredicateName
     class_methods do
       def has_one(name, &config)
-        define_method(name) do |value = nil, attributes = nil, &block|
-          return get_element(name) unless value || block
+        define_method(name) do |attributes = nil, &block|
+          return get_element(name) unless attributes || block
 
-          element_class = config ? Class.new(Element, &config) : Element
+          element_class = config ? Class.new(Element, &config) : Class.new(Element)
+          element = element_class.new(@view, attributes, &block)
 
-          set_element(
-            name, element(element_class, value, attributes, &block)
-          )
+          set_element(name, element)
         end
       end
 
       def has_many(name, &config)
-        define_method(name) do |value = nil, attributes = nil, &block|
-          return get_element(name, collection: true) unless value || block
+        define_method(name) do |attributes = nil, &block|
+          return get_element(name, collection: true) unless attributes || block
 
-          element_class = config ? Class.new(Element, &config) : Element
+          element_class = config ? Class.new(Element, &config) : Class.new(Element)
+          element = element_class.new(@view, attributes, &block)
 
-          set_element(
-            name, element(element_class, value, attributes, &block), collection: true
-          )
+          set_element(name, element, collection: true)
         end
       end
     end
     # rubocop:enable Naming/PredicateName
 
     private
-
-    def element(element_class, value, attributes, &block)
-      attributes, value = value, nil if block
-      element_class.new(@view, value, attributes, &block)
-    end
 
     def get_element(name, collection: false)
       unless instance_variable_defined?(:"@#{name}")

--- a/lib/components/elements.rb
+++ b/lib/components/elements.rb
@@ -2,31 +2,38 @@ module Components
   module Elements
     extend ActiveSupport::Concern
 
-    # rubocop:disable Naming/PredicateName
     class_methods do
+      # rubocop:disable Naming/PredicateName
       def has_one(name, &config)
         define_method(name) do |attributes = nil, &block|
           return get_element(name) unless attributes || block
 
-          element_class = config ? Class.new(Element, &config) : Class.new(Element)
-          element = element_class.new(@view, attributes, &block)
+          element_class = config ? Class.new(Element, &config) : Element
 
-          set_element(name, element)
+          set_element(
+            name,
+            element_class.new(@view, attributes, &block)
+          )
         end
       end
+      # rubocop:enable Naming/PredicateName
 
+      # rubocop:disable Naming/PredicateName
       def has_many(name, &config)
         define_method(name) do |attributes = nil, &block|
           return get_element(name, collection: true) unless attributes || block
 
-          element_class = config ? Class.new(Element, &config) : Class.new(Element)
-          element = element_class.new(@view, attributes, &block)
+          element_class = config ? Class.new(Element, &config) : Element
 
-          set_element(name, element, collection: true)
+          set_element(
+            name,
+            element_class.new(@view, attributes, &block),
+            collection: true
+          )
         end
       end
+      # rubocop:enable Naming/PredicateName
     end
-    # rubocop:enable Naming/PredicateName
 
     private
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -2,14 +2,16 @@ require 'test_helper'
 
 class ComponentTest < ActiveSupport::TestCase
   test 'initialize with value' do
-    component_class = Class.new(Components::Component)
-    component = component_class.new(:view, 'foo')
+    component_class = Class.new(Components::Component) do
+      attribute :foo
+    end
+    component = component_class.new(:view, value: 'foo')
     assert_equal 'foo', component.instance_variable_get(:@value)
   end
 
   test 'get value' do
     component_class = Class.new(Components::Component)
-    component = component_class.new(:view, 'foo')
+    component = component_class.new(:view, value: 'foo')
     assert_equal component.instance_variable_get(:@value), component.value
   end
 
@@ -25,7 +27,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       attribute :foo
     end
-    component = component_class.new(:view, nil, foo: 'foo')
+    component = component_class.new(:view, foo: 'foo')
     assert_equal 'foo', component.instance_variable_get(:@foo)
   end
 
@@ -41,7 +43,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       attribute :foo
     end
-    component = component_class.new(:view, nil, foo: 'foo')
+    component = component_class.new(:view, foo: 'foo')
     assert_equal component.instance_variable_get(:@foo), component.foo
   end
 
@@ -50,7 +52,7 @@ class ComponentTest < ActiveSupport::TestCase
       has_one :foo
     end
     component = component_class.new(:view)
-    component.foo 'foo'
+    component.foo value: 'foo'
     assert_equal 'foo', component.instance_variable_get(:@foo).value
   end
 
@@ -70,7 +72,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
     end
     component = component_class.new(:view)
-    component.foo 'foo', bar: 'baz'
+    component.foo value: 'foo', bar: 'baz'
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
     assert_equal 'baz', component.instance_variable_get(:@foo).bar
   end
 
@@ -81,76 +84,77 @@ class ComponentTest < ActiveSupport::TestCase
       end
     end
     component = component_class.new(:view)
-    component.foo 'foo'
+    component.foo value: 'foo'
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
     assert_equal 'baz', component.instance_variable_get(:@foo).bar
   end
 
-  test 'set element collection' do
-    component_class = Class.new(Components::Component) do
-      has_many :foo
-    end
-    component = component_class.new(:view)
-    component.foo 'foo'
-    component.foo 'bar'
-    assert_equal 2, component.instance_variable_get(:@foo).length
-    assert_equal 'foo', component.instance_variable_get(:@foo)[0].value
-    assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
-  end
-
-  test 'set element with nested element' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo do
-        has_one :bar
-      end
-    end
-    component = component_class.new(view_class.new)
-    component.foo baz: 'baz' do |cc|
-      cc.bar 'bar'
-      'foo'
-    end
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
-  end
-
-  test 'set element with nested element with block' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo do
-        has_one :bar
-      end
-    end
-    component = component_class.new(view_class.new)
-    component.foo baz: 'baz' do |cc|
-      cc.bar { 'bar' }
-      'foo'
-    end
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
-  end
-
-  test 'get element' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo
-    end
-    component = component_class.new(:view)
-    component.foo 'foo'
-    assert_equal component.instance_variable_get(:@foo), component.foo
-  end
-
-  test 'get element when not set' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo
-    end
-    component = component_class.new(:view)
-    assert_nil component.foo
-  end
-
-  test 'get element collection when not set' do
-    component_class = Class.new(Components::Component) do
-      has_many :foo
-    end
-    component = component_class.new(:view)
-    assert_equal [], component.foo
-  end
+  # test 'set element collection' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_many :foo
+  #   end
+  #   component = component_class.new(:view)
+  #   component.foo 'foo'
+  #   component.foo 'bar'
+  #   assert_equal 2, component.instance_variable_get(:@foo).length
+  #   assert_equal 'foo', component.instance_variable_get(:@foo)[0].value
+  #   assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
+  # end
+  #
+  # test 'set element with nested element' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_one :foo do
+  #       has_one :bar
+  #     end
+  #   end
+  #   component = component_class.new(view_class.new)
+  #   component.foo baz: 'baz' do |cc|
+  #     cc.bar 'bar'
+  #     'foo'
+  #   end
+  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
+  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  # end
+  #
+  # test 'set element with nested element with block' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_one :foo do
+  #       has_one :bar
+  #     end
+  #   end
+  #   component = component_class.new(view_class.new)
+  #   component.foo baz: 'baz' do |cc|
+  #     cc.bar { 'bar' }
+  #     'foo'
+  #   end
+  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
+  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  # end
+  #
+  # test 'get element' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_one :foo
+  #   end
+  #   component = component_class.new(:view)
+  #   component.foo 'foo'
+  #   assert_equal component.instance_variable_get(:@foo), component.foo
+  # end
+  #
+  # test 'get element when not set' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_one :foo
+  #   end
+  #   component = component_class.new(:view)
+  #   assert_nil component.foo
+  # end
+  #
+  # test 'get element collection when not set' do
+  #   component_class = Class.new(Components::Component) do
+  #     has_many :foo
+  #   end
+  #   component = component_class.new(:view)
+  #   assert_equal [], component.foo
+  # end
 
   private
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -1,28 +1,16 @@
 require 'test_helper'
 
 class ComponentTest < ActiveSupport::TestCase
-  test 'initialize with no value' do
-    component_class = Class.new(Components::Component)
-    component = component_class.new(:view)
-    assert_nil component.instance_variable_get(:@value)
-  end
-
-  test 'initialize with value' do
-    component_class = Class.new(Components::Component)
-    component = component_class.new(:view, value: 'foo')
-    assert_equal 'foo', component.instance_variable_get(:@value)
-  end
-
-  test 'initialize with value using block' do
+  test 'initialize with content' do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { 'foo' }
-    assert_equal 'foo', component.instance_variable_get(:@value)
+    assert_equal 'foo', component.instance_variable_get(:@content)
   end
 
-  test 'get value' do
+  test 'get yield' do
     component_class = Class.new(Components::Component)
-    component = component_class.new(:view, value: 'foo')
-    assert_equal component.instance_variable_get(:@value), component.value
+    component = component_class.new(view_class.new) { 'foo' }
+    assert_equal component.instance_variable_get(:@content), component.content
   end
 
   test 'initialize attribute with no value' do
@@ -57,22 +45,13 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal component.instance_variable_get(:@foo), component.foo
   end
 
-  test 'initialize element with value' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo
-    end
-    component = component_class.new(:view)
-    component.foo value: 'foo'
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-  end
-
-  test 'initialize element with value using block' do
+  test 'initialize element with content' do
     component_class = Class.new(Components::Component) do
       has_one :foo
     end
     component = component_class.new(view_class.new)
     component.foo { 'foo' }
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    assert_equal 'foo', component.instance_variable_get(:@foo).content
   end
 
   test 'initialize element with attribute with value' do
@@ -82,36 +61,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
     end
     component = component_class.new(:view)
-    component.foo value: 'foo', bar: 'baz'
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    component.foo bar: 'baz'
     assert_equal 'baz', component.instance_variable_get(:@foo).bar
-  end
-
-  test 'initialize element with attribute with default value' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo do
-        attribute :bar, default: 'baz'
-      end
-    end
-    component = component_class.new(:view)
-    component.foo value: 'foo'
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-    assert_equal 'baz', component.instance_variable_get(:@foo).bar
-  end
-
-  test 'initialize element with nested element with value' do
-    component_class = Class.new(Components::Component) do
-      has_one :foo do
-        has_one :bar
-      end
-    end
-    component = component_class.new(view_class.new)
-    component.foo do |cc|
-      cc.bar value: 'bar'
-      'foo'
-    end
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
   end
 
   test 'initialize element with nested element with value using block' do
@@ -125,28 +76,28 @@ class ComponentTest < ActiveSupport::TestCase
       cc.bar { 'bar' }
       'foo'
     end
-    assert_equal 'foo', component.instance_variable_get(:@foo).value
-    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+    assert_equal 'foo', component.instance_variable_get(:@foo).content
+    assert_equal 'bar', component.instance_variable_get(:@foo).bar.content
   end
 
   test 'initialize collection elements' do
     component_class = Class.new(Components::Component) do
       has_many :foo
     end
-    component = component_class.new(:view)
-    component.foo value: 'foo'
-    component.foo value: 'bar'
+    component = component_class.new(view_class.new)
+    component.foo { 'foo' }
+    component.foo { 'bar' }
     assert_equal 2, component.instance_variable_get(:@foo).length
-    assert_equal 'foo', component.instance_variable_get(:@foo)[0].value
-    assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
+    assert_equal 'foo', component.instance_variable_get(:@foo)[0].content
+    assert_equal 'bar', component.instance_variable_get(:@foo)[1].content
   end
 
   test 'get element' do
     component_class = Class.new(Components::Component) do
       has_one :foo
     end
-    component = component_class.new(:view)
-    component.foo value: 'foo'
+    component = component_class.new(view_class.new)
+    component.foo { 'foo' }
     assert_equal component.instance_variable_get(:@foo), component.foo
   end
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -1,11 +1,21 @@
 require 'test_helper'
 
 class ComponentTest < ActiveSupport::TestCase
+  test 'initialize with no value' do
+    component_class = Class.new(Components::Component)
+    component = component_class.new(:view)
+    assert_nil component.instance_variable_get(:@value)
+  end
+
   test 'initialize with value' do
-    component_class = Class.new(Components::Component) do
-      attribute :foo
-    end
+    component_class = Class.new(Components::Component)
     component = component_class.new(:view, value: 'foo')
+    assert_equal 'foo', component.instance_variable_get(:@value)
+  end
+
+  test 'initialize with value using block' do
+    component_class = Class.new(Components::Component)
+    component = component_class.new(view_class.new) { 'foo' }
     assert_equal 'foo', component.instance_variable_get(:@value)
   end
 
@@ -47,7 +57,7 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal component.instance_variable_get(:@foo), component.foo
   end
 
-  test 'set element' do
+  test 'initialize element with value' do
     component_class = Class.new(Components::Component) do
       has_one :foo
     end
@@ -56,7 +66,7 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal 'foo', component.instance_variable_get(:@foo).value
   end
 
-  test 'set element with block' do
+  test 'initialize element with value using block' do
     component_class = Class.new(Components::Component) do
       has_one :foo
     end
@@ -65,7 +75,7 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal 'foo', component.instance_variable_get(:@foo).value
   end
 
-  test 'set element with attribute' do
+  test 'initialize element with attribute with value' do
     component_class = Class.new(Components::Component) do
       has_one :foo do
         attribute :bar
@@ -77,7 +87,7 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal 'baz', component.instance_variable_get(:@foo).bar
   end
 
-  test 'set element with attribute with default value' do
+  test 'initialize element with attribute with default value' do
     component_class = Class.new(Components::Component) do
       has_one :foo do
         attribute :bar, default: 'baz'
@@ -89,72 +99,72 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal 'baz', component.instance_variable_get(:@foo).bar
   end
 
-  # test 'set element collection' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_many :foo
-  #   end
-  #   component = component_class.new(:view)
-  #   component.foo 'foo'
-  #   component.foo 'bar'
-  #   assert_equal 2, component.instance_variable_get(:@foo).length
-  #   assert_equal 'foo', component.instance_variable_get(:@foo)[0].value
-  #   assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
-  # end
-  #
-  # test 'set element with nested element' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_one :foo do
-  #       has_one :bar
-  #     end
-  #   end
-  #   component = component_class.new(view_class.new)
-  #   component.foo baz: 'baz' do |cc|
-  #     cc.bar 'bar'
-  #     'foo'
-  #   end
-  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
-  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
-  # end
-  #
-  # test 'set element with nested element with block' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_one :foo do
-  #       has_one :bar
-  #     end
-  #   end
-  #   component = component_class.new(view_class.new)
-  #   component.foo baz: 'baz' do |cc|
-  #     cc.bar { 'bar' }
-  #     'foo'
-  #   end
-  #   assert_equal 'foo', component.instance_variable_get(:@foo).value
-  #   assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
-  # end
-  #
-  # test 'get element' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_one :foo
-  #   end
-  #   component = component_class.new(:view)
-  #   component.foo 'foo'
-  #   assert_equal component.instance_variable_get(:@foo), component.foo
-  # end
-  #
-  # test 'get element when not set' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_one :foo
-  #   end
-  #   component = component_class.new(:view)
-  #   assert_nil component.foo
-  # end
-  #
-  # test 'get element collection when not set' do
-  #   component_class = Class.new(Components::Component) do
-  #     has_many :foo
-  #   end
-  #   component = component_class.new(:view)
-  #   assert_equal [], component.foo
-  # end
+  test 'initialize element with nested element with value' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo do
+        has_one :bar
+      end
+    end
+    component = component_class.new(view_class.new)
+    component.foo do |cc|
+      cc.bar value: 'bar'
+      'foo'
+    end
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  end
+
+  test 'initialize element with nested element with value using block' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo do
+        has_one :bar
+      end
+    end
+    component = component_class.new(view_class.new)
+    component.foo do |cc|
+      cc.bar { 'bar' }
+      'foo'
+    end
+    assert_equal 'foo', component.instance_variable_get(:@foo).value
+    assert_equal 'bar', component.instance_variable_get(:@foo).bar.value
+  end
+
+  test 'initialize collection elements' do
+    component_class = Class.new(Components::Component) do
+      has_many :foo
+    end
+    component = component_class.new(:view)
+    component.foo value: 'foo'
+    component.foo value: 'bar'
+    assert_equal 2, component.instance_variable_get(:@foo).length
+    assert_equal 'foo', component.instance_variable_get(:@foo)[0].value
+    assert_equal 'bar', component.instance_variable_get(:@foo)[1].value
+  end
+
+  test 'get element' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo
+    end
+    component = component_class.new(:view)
+    component.foo value: 'foo'
+    assert_equal component.instance_variable_get(:@foo), component.foo
+  end
+
+  test 'get element when not set' do
+    component_class = Class.new(Components::Component) do
+      has_one :foo
+    end
+    component = component_class.new(:view)
+    assert_nil component.foo
+  end
+
+  test 'get element collection when not set' do
+    component_class = Class.new(Components::Component) do
+      has_many :foo
+    end
+    component = component_class.new(:view)
+    assert_equal [], component.foo
+  end
 
   private
 

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= id %>" class="card">
   <% if header.present? %>
     <div class="card__header">
-      <%= header %>
+      <%= header.content %>
     </div>
   <% end %>
   <% sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
       <% if section.header.present? %>
         <div class="card__section__header">
-          <%= section.header %>
+          <%= section.header.content %>
         </div>
       <% end %>
-      <%= section %>
+      <%= section.content %>
     </div>
   <% end %>
   <% if footer.present? %>
     <div class="card__footer">
-      <%= footer %>
+      <%= footer.content %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media %>
+    <%= media.content %>
   </div>
   <div class="media-object__body">
-    <%= body %>
+    <%= body.content %>
   </div>
 </div>

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -3,86 +3,86 @@ require 'test_helper'
 class ComponentHelperTest < ActionView::TestCase
   include Components::ComponentHelper
 
-  test 'render component setting elements' do
-    output = component 'card', id: 'id' do |c|
-      c.header 'Header'
-      c.sections 'Section 1', size: 'large'
-      c.sections 'Section 2', size: 'small'
-      c.footer 'Footer'
-    end
-
-    assert_dom_equal_squished %(
-      <div id="id" class="card">
-        <div class="card__header"> Header </div>
-        <div class="card__section card__section--large"> Section 1 </div>
-        <div class="card__section card__section--small"> Section 2 </div>
-        <div class="card__footer"> Footer </div>
-      </div>
-    ), output
-  end
-
-  test 'render component setting elements with blocks' do
-    output = component 'card', id: 'id' do |c|
-      c.header { 'Header' }
-      c.sections(size: 'large') { 'Section 1' }
-      c.sections(size: 'small') { 'Section 2' }
-      c.footer { 'Footer' }
-    end
-
-    assert_dom_equal_squished %(
-      <div id="id" class="card">
-        <div class="card__header"> Header </div>
-        <div class="card__section card__section--large"> Section 1 </div>
-        <div class="card__section card__section--small"> Section 2 </div>
-        <div class="card__footer"> Footer </div>
-      </div>
-    ), output
-  end
-
-  test 'render component setting nested elements' do
-    output = component 'card', id: 'id' do |c|
-      c.header 'Header'
-      c.header { 'Header' }
-      c.sections do |cc|
-        cc.header { 'Section Header 1' }
-        'Section 1'
-      end
-      c.sections do |cc|
-        cc.header { 'Section Header 2' }
-        'Section 2'
-      end
-      c.footer { 'Footer' }
-    end
-
-    assert_dom_equal_squished %(
-      <div id="id" class="card">
-        <div class="card__header"> Header </div>
-        <div class="card__section">
-          <div class="card__section__header"> Section Header 1 </div>
-          Section 1
-        </div>
-        <div class="card__section">
-          <div class="card__section__header"> Section Header 2 </div>
-          Section 2
-        </div>
-        <div class="card__footer"> Footer </div>
-      </div>
-    ), output
-  end
-
-  test 'render namespaced component' do
-    output = component 'objects/media_object' do |c|
-      c.media 'Media'
-      c.body 'Body'
-    end
-
-    assert_dom_equal_squished %(
-      <div class="media-object">
-        <div class="media-object__media"> Media </div>
-        <div class="media-object__body"> Body </div>
-      </div>
-    ), output
-  end
+  # test 'render component setting elements' do
+  #   output = component 'card', id: 'id' do |c|
+  #     c.header 'Header'
+  #     c.sections 'Section 1', size: 'large'
+  #     c.sections 'Section 2', size: 'small'
+  #     c.footer 'Footer'
+  #   end
+  #
+  #   assert_dom_equal_squished %(
+  #     <div id="id" class="card">
+  #       <div class="card__header"> Header </div>
+  #       <div class="card__section card__section--large"> Section 1 </div>
+  #       <div class="card__section card__section--small"> Section 2 </div>
+  #       <div class="card__footer"> Footer </div>
+  #     </div>
+  #   ), output
+  # end
+  #
+  # test 'render component setting elements with blocks' do
+  #   output = component 'card', id: 'id' do |c|
+  #     c.header { 'Header' }
+  #     c.sections(size: 'large') { 'Section 1' }
+  #     c.sections(size: 'small') { 'Section 2' }
+  #     c.footer { 'Footer' }
+  #   end
+  #
+  #   assert_dom_equal_squished %(
+  #     <div id="id" class="card">
+  #       <div class="card__header"> Header </div>
+  #       <div class="card__section card__section--large"> Section 1 </div>
+  #       <div class="card__section card__section--small"> Section 2 </div>
+  #       <div class="card__footer"> Footer </div>
+  #     </div>
+  #   ), output
+  # end
+  #
+  # test 'render component setting nested elements' do
+  #   output = component 'card', id: 'id' do |c|
+  #     c.header 'Header'
+  #     c.header { 'Header' }
+  #     c.sections do |cc|
+  #       cc.header { 'Section Header 1' }
+  #       'Section 1'
+  #     end
+  #     c.sections do |cc|
+  #       cc.header { 'Section Header 2' }
+  #       'Section 2'
+  #     end
+  #     c.footer { 'Footer' }
+  #   end
+  #
+  #   assert_dom_equal_squished %(
+  #     <div id="id" class="card">
+  #       <div class="card__header"> Header </div>
+  #       <div class="card__section">
+  #         <div class="card__section__header"> Section Header 1 </div>
+  #         Section 1
+  #       </div>
+  #       <div class="card__section">
+  #         <div class="card__section__header"> Section Header 2 </div>
+  #         Section 2
+  #       </div>
+  #       <div class="card__footer"> Footer </div>
+  #     </div>
+  #   ), output
+  # end
+  #
+  # test 'render namespaced component' do
+  #   output = component 'objects/media_object' do |c|
+  #     c.media 'Media'
+  #     c.body 'Body'
+  #   end
+  #
+  #   assert_dom_equal_squished %(
+  #     <div class="media-object">
+  #       <div class="media-object__media"> Media </div>
+  #       <div class="media-object__body"> Body </div>
+  #     </div>
+  #   ), output
+  # end
 
   private
 

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -3,25 +3,7 @@ require 'test_helper'
 class ComponentHelperTest < ActionView::TestCase
   include Components::ComponentHelper
 
-  test 'render component initializing elements with values' do
-    output = component 'card', id: 'id' do |c|
-      c.header value: 'Header'
-      c.sections value: 'Section 1', size: 'large'
-      c.sections value: 'Section 2', size: 'small'
-      c.footer value: 'Footer'
-    end
-
-    assert_dom_equal_squished %(
-      <div id="id" class="card">
-        <div class="card__header"> Header </div>
-        <div class="card__section card__section--large"> Section 1 </div>
-        <div class="card__section card__section--small"> Section 2 </div>
-        <div class="card__footer"> Footer </div>
-      </div>
-    ), output
-  end
-
-  test 'render component initializing elements with values using blocks' do
+  test 'render component with elements' do
     output = component 'card', id: 'id' do |c|
       c.header { 'Header' }
       c.sections(size: 'large') { 'Section 1' }
@@ -39,18 +21,18 @@ class ComponentHelperTest < ActionView::TestCase
     ), output
   end
 
-  test 'render component initializing nested elements with values' do
+  test 'render component with nested elements' do
     output = component 'card', id: 'id' do |c|
-      c.header value: 'Header'
+      c.header { 'Header' }
       c.sections do |cc|
-        cc.header value: 'Section Header 1'
+        cc.header { 'Section Header 1' }
         'Section 1'
       end
       c.sections do |cc|
-        cc.header value: 'Section Header 2'
+        cc.header { 'Section Header 2' }
         'Section 2'
       end
-      c.footer value: 'Footer'
+      c.footer { 'Footer' }
     end
 
     assert_dom_equal_squished %(
@@ -71,8 +53,8 @@ class ComponentHelperTest < ActionView::TestCase
 
   test 'render namespaced component' do
     output = component 'objects/media_object' do |c|
-      c.media value: 'Media'
-      c.body value: 'Body'
+      c.media { 'Media' }
+      c.body { 'Body' }
     end
 
     assert_dom_equal_squished %(

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -3,86 +3,85 @@ require 'test_helper'
 class ComponentHelperTest < ActionView::TestCase
   include Components::ComponentHelper
 
-  # test 'render component setting elements' do
-  #   output = component 'card', id: 'id' do |c|
-  #     c.header 'Header'
-  #     c.sections 'Section 1', size: 'large'
-  #     c.sections 'Section 2', size: 'small'
-  #     c.footer 'Footer'
-  #   end
-  #
-  #   assert_dom_equal_squished %(
-  #     <div id="id" class="card">
-  #       <div class="card__header"> Header </div>
-  #       <div class="card__section card__section--large"> Section 1 </div>
-  #       <div class="card__section card__section--small"> Section 2 </div>
-  #       <div class="card__footer"> Footer </div>
-  #     </div>
-  #   ), output
-  # end
-  #
-  # test 'render component setting elements with blocks' do
-  #   output = component 'card', id: 'id' do |c|
-  #     c.header { 'Header' }
-  #     c.sections(size: 'large') { 'Section 1' }
-  #     c.sections(size: 'small') { 'Section 2' }
-  #     c.footer { 'Footer' }
-  #   end
-  #
-  #   assert_dom_equal_squished %(
-  #     <div id="id" class="card">
-  #       <div class="card__header"> Header </div>
-  #       <div class="card__section card__section--large"> Section 1 </div>
-  #       <div class="card__section card__section--small"> Section 2 </div>
-  #       <div class="card__footer"> Footer </div>
-  #     </div>
-  #   ), output
-  # end
-  #
-  # test 'render component setting nested elements' do
-  #   output = component 'card', id: 'id' do |c|
-  #     c.header 'Header'
-  #     c.header { 'Header' }
-  #     c.sections do |cc|
-  #       cc.header { 'Section Header 1' }
-  #       'Section 1'
-  #     end
-  #     c.sections do |cc|
-  #       cc.header { 'Section Header 2' }
-  #       'Section 2'
-  #     end
-  #     c.footer { 'Footer' }
-  #   end
-  #
-  #   assert_dom_equal_squished %(
-  #     <div id="id" class="card">
-  #       <div class="card__header"> Header </div>
-  #       <div class="card__section">
-  #         <div class="card__section__header"> Section Header 1 </div>
-  #         Section 1
-  #       </div>
-  #       <div class="card__section">
-  #         <div class="card__section__header"> Section Header 2 </div>
-  #         Section 2
-  #       </div>
-  #       <div class="card__footer"> Footer </div>
-  #     </div>
-  #   ), output
-  # end
-  #
-  # test 'render namespaced component' do
-  #   output = component 'objects/media_object' do |c|
-  #     c.media 'Media'
-  #     c.body 'Body'
-  #   end
-  #
-  #   assert_dom_equal_squished %(
-  #     <div class="media-object">
-  #       <div class="media-object__media"> Media </div>
-  #       <div class="media-object__body"> Body </div>
-  #     </div>
-  #   ), output
-  # end
+  test 'render component initializing elements with values' do
+    output = component 'card', id: 'id' do |c|
+      c.header value: 'Header'
+      c.sections value: 'Section 1', size: 'large'
+      c.sections value: 'Section 2', size: 'small'
+      c.footer value: 'Footer'
+    end
+
+    assert_dom_equal_squished %(
+      <div id="id" class="card">
+        <div class="card__header"> Header </div>
+        <div class="card__section card__section--large"> Section 1 </div>
+        <div class="card__section card__section--small"> Section 2 </div>
+        <div class="card__footer"> Footer </div>
+      </div>
+    ), output
+  end
+
+  test 'render component initializing elements with values using blocks' do
+    output = component 'card', id: 'id' do |c|
+      c.header { 'Header' }
+      c.sections(size: 'large') { 'Section 1' }
+      c.sections(size: 'small') { 'Section 2' }
+      c.footer { 'Footer' }
+    end
+
+    assert_dom_equal_squished %(
+      <div id="id" class="card">
+        <div class="card__header"> Header </div>
+        <div class="card__section card__section--large"> Section 1 </div>
+        <div class="card__section card__section--small"> Section 2 </div>
+        <div class="card__footer"> Footer </div>
+      </div>
+    ), output
+  end
+
+  test 'render component initializing nested elements with values' do
+    output = component 'card', id: 'id' do |c|
+      c.header value: 'Header'
+      c.sections do |cc|
+        cc.header value: 'Section Header 1'
+        'Section 1'
+      end
+      c.sections do |cc|
+        cc.header value: 'Section Header 2'
+        'Section 2'
+      end
+      c.footer value: 'Footer'
+    end
+
+    assert_dom_equal_squished %(
+      <div id="id" class="card">
+        <div class="card__header"> Header </div>
+        <div class="card__section">
+          <div class="card__section__header"> Section Header 1 </div>
+          Section 1
+        </div>
+        <div class="card__section">
+          <div class="card__section__header"> Section Header 2 </div>
+          Section 2
+        </div>
+        <div class="card__footer"> Footer </div>
+      </div>
+    ), output
+  end
+
+  test 'render namespaced component' do
+    output = component 'objects/media_object' do |c|
+      c.media value: 'Media'
+      c.body value: 'Body'
+    end
+
+    assert_dom_equal_squished %(
+      <div class="media-object">
+        <div class="media-object__media"> Media </div>
+        <div class="media-object__body"> Body </div>
+      </div>
+    ), output
+  end
 
   private
 


### PR DESCRIPTION
This PR solves #17 and changes the elements API. Instead of having a value that can be set either with a block or as a parameter when initializing an element (and component), there is now only a content variable that can only be set with a block. This simplifies the code a bit because it doesn't have to deal with shifting parameter order. 

It also removes the `to_s` method on element. You now have to explicitly print the content variable. This makes things more consistent between components and elements.

It also hopefully clarifies the API a bit. It would have been nice to name the variable yield instead of content but that is a reserved word in Ruby.