### PR TITLE
Simplify rendering and pass hashes to templates

### DIFF
--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,19 +1,21 @@
 module Components
   module ComponentHelper
+    # attrs = nil?
     def component(name, attrs = {}, &block)
       component = "#{name}_component".classify.constantize.new(self, attrs, &block)
+      component.render
 
-      view = controller.view_context
-      view.instance_variable_set(:@_component, component)
-
-      methods = component.public_methods(false)
-      methods << :content
-
-      methods.each do |method|
-        view.singleton_class.delegate method, to: :@_component
-      end
-
-      view.render "#{name}/#{name.split('/')[-1]}"
+      # view = controller.view_context
+      # view.instance_variable_set(:@_component, component)
+      #
+      # methods = component.public_methods(false)
+      # methods << :content
+      #
+      # methods.each do |method|
+      #   view.singleton_class.delegate method, to: :@_component
+      # end
+      #
+      # view.render "#{name}/#{name.split('/')[-1]}"
     end
   end
 end

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,20 +1,7 @@
 module Components
   module ComponentHelper
     def component(name, attrs = nil, &block)
-      component = "#{name}_component".classify.constantize.new(self, attrs, &block)
-      component.render
-
-      # view = controller.view_context
-      # view.instance_variable_set(:@_component, component)
-      #
-      # methods = component.public_methods(false)
-      # methods << :content
-      #
-      # methods.each do |method|
-      #   view.singleton_class.delegate method, to: :@_component
-      # end
-      #
-      # view.render "#{name}/#{name.split('/')[-1]}"
+      "#{name}_component".classify.constantize.new(self, attrs, &block).render
     end
   end
 end

--- a/app/helpers/components/component_helper.rb
+++ b/app/helpers/components/component_helper.rb
@@ -1,7 +1,6 @@
 module Components
   module ComponentHelper
-    # attrs = nil?
-    def component(name, attrs = {}, &block)
+    def component(name, attrs = nil, &block)
       component = "#{name}_component".classify.constantize.new(self, attrs, &block)
       component.render
 

--- a/lib/components/attributes.rb
+++ b/lib/components/attributes.rb
@@ -22,19 +22,18 @@ module Components
       attributes ||= {}
 
       self.class.attributes.each do |name, options|
-        self.attributes[name] = attributes.delete(name) || (options[:default] && options[:default].dup)
+        self.attributes[name] = attributes[name] || (options[:default] && options[:default].dup)
       end
     end
 
-    # TODO: this shouldn't modify the attributes hash.. instead it should
-    # return a new hash..
     def serialize_attributes
-      attributes.tap do |hash|
-        self.class.attributes.each do |name, options|
-          if options[:block]
-            hash[name] = instance_exec(hash[name], &options[:block])
+      attributes.each_with_object({}) do |(name, value), hash|
+        hash[name] =
+          if (block = self.class.attributes[name][:block])
+            instance_exec(value, &block)
+          else
+            value
           end
-        end
       end
     end
   end

--- a/lib/components/attributes.rb
+++ b/lib/components/attributes.rb
@@ -19,20 +19,18 @@ module Components
     end
 
     def initialize_attributes(attributes)
-      attributes ||= {}
-
       self.class.attributes.each do |name, options|
         self.attributes[name] = attributes[name] || (options[:default] && options[:default].dup)
       end
     end
 
     def serialize_attributes
-      attributes.each_with_object({}) do |(name, value), hash|
+      self.class.attributes.each_with_object({}) do |(name, options), hash|
         hash[name] =
-          if (block = self.class.attributes[name][:block])
-            instance_exec(value, &block)
+          if (block = options[:block])
+            instance_exec(attributes[name], &block)
           else
-            value
+            attributes[name]
           end
       end
     end

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,4 +1,7 @@
 module Components
   class Component < Element
+    def render
+      @view.render 'card/card', to_h
+    end
   end
 end

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,8 +1,19 @@
 module Components
   class Component < Element
-    # TODO: we need to calculate the proper component name here
+    def self.component_name
+      name.chomp('Component').demodulize.underscore
+    end
+
+    def self.component_path
+      name.chomp('Component').underscore
+    end
+
     def render
-      @view.render 'card/card', serialize
+      @view.render partial: to_partial_path, object: serialize
+    end
+
+    def to_partial_path
+      [self.class.component_path, self.class.component_name].join('/')
     end
   end
 end

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -9,7 +9,7 @@ module Components
     end
 
     def render
-      @view.render partial: to_partial_path, object: serialize
+      @view.render partial: to_partial_path, locals: serialize
     end
 
     def to_partial_path

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,7 +1,8 @@
 module Components
   class Component < Element
+    # TODO: we need to calculate the proper component name here
     def render
-      @view.render 'card/card', to_h
+      @view.render 'card/card', serialize
     end
   end
 end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -7,7 +7,7 @@ module Components
 
     def initialize(view, attributes = nil, &block)
       @view = view
-      initialize_attributes(attributes)
+      initialize_attributes(attributes || {})
       initialize_elements
       initialize_content(&block)
     end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -7,14 +7,36 @@ module Components
 
     def initialize(view, attributes = nil, &block)
       @view = view
-      @content = capture(&block) if block
-      assign_attributes(attributes || {})
+      initialize_elements
+      initialize_attributes(attributes)
+      initialize_content(&block)
     end
 
-    private
+    def to_h
+      serialize_attributes
+        .merge(serialize_content)
+        .merge(serialize_elements)
+    end
 
-    def capture(&block)
-      @view.capture(self, &block)
+    protected
+
+    def initialize_content(&block)
+      @content = @view.capture(self, &block) if block
+    end
+
+    def serialize_content
+      { content: content }
+    end
+
+    def serialize_elements
+      elements.each_with_object({}) do |(key, value), hash|
+        hash[key] =
+          if value.respond_to?(:map) # should we rather check the config here?
+            value.map(&:to_h)
+          else
+            value ? value.to_h : nil
+          end
+      end
     end
   end
 end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -3,32 +3,18 @@ module Components
     include Attributes
     include Elements
 
-    attr_reader :content
-
     def initialize(view, attributes = nil, &block)
       @view = view
       initialize_attributes(attributes || {})
       initialize_elements
-      initialize_content(&block)
+      @yield = block ? @view.capture(self, &block) : nil
     end
 
+    # TODO: consider skipping yield altogether if none was set
     def serialize
-      serialize_attributes
+      { yield: @yield }
+        .merge(serialize_attributes)
         .merge(serialize_elements)
-        .merge(serialize_content)
-    end
-
-    protected
-
-    # TODO: move block things to its own module as well? perhaps wait
-    # until we know what to call it.. or move everything in here and
-    # remove the modules altogether...
-    def initialize_content(&block)
-      @content = @view.capture(self, &block) if block
-    end
-
-    def serialize_content
-      { content: content }
     end
   end
 end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -7,36 +7,28 @@ module Components
 
     def initialize(view, attributes = nil, &block)
       @view = view
-      initialize_elements
       initialize_attributes(attributes)
+      initialize_elements
       initialize_content(&block)
     end
 
-    def to_h
+    def serialize
       serialize_attributes
-        .merge(serialize_content)
         .merge(serialize_elements)
+        .merge(serialize_content)
     end
 
     protected
 
+    # TODO: move block things to its own module as well? perhaps wait
+    # until we know what to call it.. or move everything in here and
+    # remove the modules altogether...
     def initialize_content(&block)
       @content = @view.capture(self, &block) if block
     end
 
     def serialize_content
       { content: content }
-    end
-
-    def serialize_elements
-      elements.each_with_object({}) do |(key, value), hash|
-        hash[key] =
-          if value.respond_to?(:map) # should we rather check the config here?
-            value.map(&:to_h)
-          else
-            value ? value.to_h : nil
-          end
-      end
     end
   end
 end

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -1,49 +1,40 @@
 require 'test_helper'
 
 class ComponentTest < ActiveSupport::TestCase
-  test 'to_h when initialized with nothing' do
+  test 'serialize when initialized with nothing' do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
     assert_equal ({
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with content' do
+  test 'serialize when initialized with content' do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { 'foo' }
     assert_equal ({
       content: 'foo'
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with attributes' do
+  test 'serialize when initialized with attributes' do
     component_class = Class.new(Components::Component) do
       attribute :foo
       attribute :bar
       attribute :baz, default: 'baz'
+      attribute :qux, &:upcase
     end
-    component = component_class.new(:view, bar: 'bar')
+    component = component_class.new(:view, bar: 'bar', qux: 'qux')
     assert_equal ({
       foo: nil,
       bar: 'bar',
       baz: 'baz',
+      qux: 'QUX',
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with attribute with override' do
-    component_class = Class.new(Components::Component) do
-      attribute :foo, &:upcase
-    end
-    component = component_class.new(:view, foo: 'foo')
-    assert_equal ({
-      foo: 'FOO',
-      content: nil
-    }), component.to_h
-  end
-
-  test 'to_h when element not initialized' do
+  test 'serialize when element not initialized' do
     component_class = Class.new(Components::Component) do
       element :foo
     end
@@ -51,10 +42,10 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal ({
       foo: nil,
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when multi-element not initialized' do
+  test 'serialize when multi-element not initialized' do
     component_class = Class.new(Components::Component) do
       element :foo, multiple: true
     end
@@ -62,10 +53,10 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal ({
       foo: [],
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with element with content' do
+  test 'serialize when initialized with element with content' do
     component_class = Class.new(Components::Component) do
       element :foo
     end
@@ -76,31 +67,33 @@ class ComponentTest < ActiveSupport::TestCase
         content: 'foo'
       },
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with element with attributes' do
+  test 'serialize when initialized with element with attributes' do
     component_class = Class.new(Components::Component) do
       element :foo do
         attribute :foo
         attribute :bar
         attribute :baz, default: 'baz'
+        attribute :qux, &:upcase
       end
     end
     component = component_class.new(:view)
-    component.foo bar: 'bar'
+    component.foo(bar: 'bar', qux: 'qux')
     assert_equal ({
       foo: {
         foo: nil,
         bar: 'bar',
         baz: 'baz',
+        qux: 'QUX',
         content: nil
       },
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with multi-element' do
+  test 'serialize when initialized with multi-element' do
     component_class = Class.new(Components::Component) do
       element :foo, multiple: true
     end
@@ -113,10 +106,10 @@ class ComponentTest < ActiveSupport::TestCase
         { content: 'bar' }
       ],
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
-  test 'to_h when initialized with element with content and nested element with content' do
+  test 'serialize when initialized with element with content and nested element with content' do
     component_class = Class.new(Components::Component) do
       element :foo do
         element :bar
@@ -135,7 +128,7 @@ class ComponentTest < ActiveSupport::TestCase
         content: 'foo'
       },
       content: nil
-    }), component.to_h
+    }), component.serialize
   end
 
   private

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -5,7 +5,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
     assert_equal ({
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -13,7 +13,7 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { 'foo' }
     assert_equal ({
-      content: 'foo'
+      yield: 'foo'
     }), component.serialize
   end
 
@@ -30,7 +30,7 @@ class ComponentTest < ActiveSupport::TestCase
       bar: 'bar',
       baz: 'baz',
       qux: 'QUX',
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -41,7 +41,7 @@ class ComponentTest < ActiveSupport::TestCase
     component = component_class.new(view_class.new)
     assert_equal ({
       foo: nil,
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -52,7 +52,7 @@ class ComponentTest < ActiveSupport::TestCase
     component = component_class.new(view_class.new)
     assert_equal ({
       foos: [],
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -64,9 +64,9 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { 'foo' }
     assert_equal ({
       foo: {
-        content: 'foo'
+        yield: 'foo'
       },
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -87,9 +87,9 @@ class ComponentTest < ActiveSupport::TestCase
         bar: 'bar',
         baz: 'baz',
         qux: 'QUX',
-        content: nil
+        yield: nil
       },
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -102,10 +102,10 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { 'bar' }
     assert_equal ({
       foos: [
-        { content: 'foo' },
-        { content: 'bar' }
+        { yield: 'foo' },
+        { yield: 'bar' }
       ],
-      content: nil
+      yield: nil
     }), component.serialize
   end
 
@@ -123,11 +123,11 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal ({
       foo: {
         bar: {
-          content: 'bar'
+          yield: 'bar'
         },
-        content: 'foo'
+        yield: 'foo'
       },
-      content: nil
+      yield: nil
     }), component.serialize
   end
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -51,7 +51,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     assert_equal ({
-      foo: [],
+      foos: [],
       content: nil
     }), component.serialize
   end
@@ -101,7 +101,7 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { 'foo' }
     component.foo { 'bar' }
     assert_equal ({
-      foo: [
+      foos: [
         { content: 'foo' },
         { content: 'bar' }
       ],

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -4,7 +4,7 @@
       <%= header[:content] %>
     </div>
   <% end %>
-  <% section.each do |section| %>
+  <% sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section[:size]}" if section[:size] %>">
       <% if section[:header].present? %>
         <div class="card__section__header">

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= id %>" class="card">
   <% if header.present? %>
     <div class="card__header">
-      <%= header[:content] %>
+      <%= header[:yield] %>
     </div>
   <% end %>
   <% sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section[:size]}" if section[:size] %>">
       <% if section[:header].present? %>
         <div class="card__section__header">
-          <%= section[:header][:content] %>
+          <%= section[:header][:yield] %>
         </div>
       <% end %>
-      <%= section[:content] %>
+      <%= section[:yield] %>
     </div>
   <% end %>
   <% if footer.present? %>
     <div class="card__footer">
-      <%= footer[:content] %>
+      <%= footer[:yield] %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,10 +1,10 @@
-<div id="<%= card[:id] %>" class="card">
-  <% if (header = card[:header]) %>
+<div id="<%= id %>" class="card">
+  <% if header.present? %>
     <div class="card__header">
       <%= header[:content] %>
     </div>
   <% end %>
-  <% card[:sections].each do |section| %>
+  <% sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section[:size]}" if section[:size] %>">
       <% if section[:header].present? %>
         <div class="card__section__header">
@@ -14,7 +14,7 @@
       <%= section[:content] %>
     </div>
   <% end %>
-  <% if (footer = card[:footer]) %>
+  <% if footer.present? %>
     <div class="card__footer">
       <%= footer[:content] %>
     </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= id %>" class="card">
   <% if header.present? %>
     <div class="card__header">
-      <%= header.content %>
+      <%= header[:content] %>
     </div>
   <% end %>
-  <% sections.each do |section| %>
-    <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
-      <% if section.header.present? %>
+  <% section.each do |section| %>
+    <div class="card__section<%= " card__section--#{section[:size]}" if section[:size] %>">
+      <% if section[:header].present? %>
         <div class="card__section__header">
-          <%= section.header.content %>
+          <%= section[:header][:content] %>
         </div>
       <% end %>
-      <%= section.content %>
+      <%= section[:content] %>
     </div>
   <% end %>
   <% if footer.present? %>
     <div class="card__footer">
-      <%= footer.content %>
+      <%= footer[:content] %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,10 +1,10 @@
-<div id="<%= id %>" class="card">
-  <% if header.present? %>
+<div id="<%= card[:id] %>" class="card">
+  <% if (header = card[:header]) %>
     <div class="card__header">
       <%= header[:content] %>
     </div>
   <% end %>
-  <% sections.each do |section| %>
+  <% card[:sections].each do |section| %>
     <div class="card__section<%= " card__section--#{section[:size]}" if section[:size] %>">
       <% if section[:header].present? %>
         <div class="card__section__header">
@@ -14,7 +14,7 @@
       <%= section[:content] %>
     </div>
   <% end %>
-  <% if footer.present? %>
+  <% if (footer = card[:footer]) %>
     <div class="card__footer">
       <%= footer[:content] %>
     </div>

--- a/test/dummy/app/components/card_component.rb
+++ b/test/dummy/app/components/card_component.rb
@@ -1,10 +1,9 @@
 class CardComponent < Components::Component
   attribute :id
-
-  has_one :header
-  has_many :sections do
+  element :header
+  element :section, multiple: true do
     attribute :size
-    has_one :header
+    element :header
   end
-  has_one :footer
+  element :footer
 end

--- a/test/dummy/app/components/card_component.rb
+++ b/test/dummy/app/components/card_component.rb
@@ -1,5 +1,6 @@
 class CardComponent < Components::Component
   attribute :id
+  attribute :class
   element :header
   element :section, multiple: true do
     attribute :size

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media_object[:media][:content] %>
+    <%= media[:content] %>
   </div>
   <div class="media-object__body">
-    <%= media_object[:body][:content] %>
+    <%= body[:content] %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media[:content] %>
+    <%= media[:yield] %>
   </div>
   <div class="media-object__body">
-    <%= body[:content] %>
+    <%= body[:yield] %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media.content %>
+    <%= media[:content] %>
   </div>
   <div class="media-object__body">
-    <%= body.content %>
+    <%= body[:content] %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media[:content] %>
+    <%= media_object[:media][:content] %>
   </div>
   <div class="media-object__body">
-    <%= body[:content] %>
+    <%= media_object[:body][:content] %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object_component.rb
+++ b/test/dummy/app/components/objects/media_object_component.rb
@@ -1,6 +1,6 @@
 module Objects
   class MediaObjectComponent < Components::Component
-    has_one :media
-    has_one :body
+    element :media
+    element :body
   end
 end

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -51,19 +51,19 @@ class ComponentHelperTest < ActionView::TestCase
     ), output
   end
 
-  # test 'render namespaced component' do
-  #   output = component 'objects/media_object' do |c|
-  #     c.media { 'Media' }
-  #     c.body { 'Body' }
-  #   end
-  #
-  #   assert_dom_equal_squished %(
-  #     <div class="media-object">
-  #       <div class="media-object__media"> Media </div>
-  #       <div class="media-object__body"> Body </div>
-  #     </div>
-  #   ), output
-  # end
+  test 'render namespaced component' do
+    output = component 'objects/media_object' do |c|
+      c.media { 'Media' }
+      c.body { 'Body' }
+    end
+
+    assert_dom_equal_squished %(
+      <div class="media-object">
+        <div class="media-object__media"> Media </div>
+        <div class="media-object__body"> Body </div>
+      </div>
+    ), output
+  end
 
   private
 

--- a/test/helpers/component_helper_test.rb
+++ b/test/helpers/component_helper_test.rb
@@ -6,8 +6,8 @@ class ComponentHelperTest < ActionView::TestCase
   test 'render component with elements' do
     output = component 'card', id: 'id' do |c|
       c.header { 'Header' }
-      c.sections(size: 'large') { 'Section 1' }
-      c.sections(size: 'small') { 'Section 2' }
+      c.section(size: 'large') { 'Section 1' }
+      c.section(size: 'small') { 'Section 2' }
       c.footer { 'Footer' }
     end
 
@@ -24,11 +24,11 @@ class ComponentHelperTest < ActionView::TestCase
   test 'render component with nested elements' do
     output = component 'card', id: 'id' do |c|
       c.header { 'Header' }
-      c.sections do |cc|
+      c.section do |cc|
         cc.header { 'Section Header 1' }
         'Section 1'
       end
-      c.sections do |cc|
+      c.section do |cc|
         cc.header { 'Section Header 2' }
         'Section 2'
       end
@@ -51,19 +51,19 @@ class ComponentHelperTest < ActionView::TestCase
     ), output
   end
 
-  test 'render namespaced component' do
-    output = component 'objects/media_object' do |c|
-      c.media { 'Media' }
-      c.body { 'Body' }
-    end
-
-    assert_dom_equal_squished %(
-      <div class="media-object">
-        <div class="media-object__media"> Media </div>
-        <div class="media-object__body"> Body </div>
-      </div>
-    ), output
-  end
+  # test 'render namespaced component' do
+  #   output = component 'objects/media_object' do |c|
+  #     c.media { 'Media' }
+  #     c.body { 'Body' }
+  #   end
+  #
+  #   assert_dom_equal_squished %(
+  #     <div class="media-object">
+  #       <div class="media-object__media"> Media </div>
+  #       <div class="media-object__body"> Body </div>
+  #     </div>
+  #   ), output
+  # end
 
   private
 


### PR DESCRIPTION
This PR changes rendering quite a bit, and also the API. The building of components API stays mostly the same, but the data passed to the partial is now a hash instead of the component object itself. This is one alternative to solve #19. Will attempt another where the component is still passed to the template.

Some pros with this solution:
- Do not need a top level key
- Can use reserved words such as `yield` and `class`

(We could add a top level key as well if we want to, and then wouldn't have to use `local_assigns` for reserved words)

## Todo

- [x] Serialize components to hashes
- [x] Add pluralization support
- [x] Render correct template based on component name
- [x] Rename `content` to `yield`
- [x] Create separate PR where component is still passed to template, for comparison
- [ ] General clean up if we move forward with this one